### PR TITLE
[Feat] 프로필화면에서 작성한 글 확인 기능 구현

### DIFF
--- a/app/src/main/java/com/brandon/campingmate/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/brandon/campingmate/presentation/login/LoginActivity.kt
@@ -72,8 +72,7 @@ class LoginActivity : AppCompatActivity() {
                         "nickName" to "${user?.kakaoAccount?.profile?.nickname}",
                         "profileImage" to null,
                         "userEmail" to "${user?.kakaoAccount?.email}",
-                        "bookmarked" to null,
-                        "writing" to null
+                        "bookmarked" to null
                     )
                     val documentRef = db.collection("users").document("Kakao${user?.id}")
                     documentRef.get().addOnSuccessListener {

--- a/app/src/main/java/com/brandon/campingmate/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/brandon/campingmate/presentation/profile/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.brandon.campingmate.domain.model.CampEntity
+import com.brandon.campingmate.domain.model.PostEntity
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
@@ -15,20 +16,21 @@ class ProfileViewModel : ViewModel() {
     val bookmarkedList: LiveData<List<CampEntity>> get() = _bookmarkedList
     private val bookmarkCamp: MutableList<CampEntity> = mutableListOf()
 
+    private val _postList : MutableLiveData<List<PostEntity>> = MutableLiveData()
+    val postList : LiveData<List<PostEntity>> get() = _postList
+    private val writingPost : MutableList<PostEntity> = mutableListOf()
+
     fun getBookmark(userID: String) {
-        Timber.tag("겟북마크검사").d("작동중")
         val db = FirebaseFirestore.getInstance()
         val docRef = db.collection("users").document("Kakao${userID}")
         val contentIds = mutableListOf<String>()
         docRef.get().addOnSuccessListener {
             if (it.exists()) {
                 val bookmarkData = it.get("bookmarked") as? List<*>
-                Timber.tag("겟북마크목록검사").d(bookmarkData.toString())
                 if (bookmarkData != null) {
                     for (item in bookmarkData) {
                         contentIds.add(item.toString())
                     }
-                    Timber.tag("북마크목록검사").d("$contentIds")
                 }
                 bookmarkCamp.clear()
                 if (contentIds.isNotEmpty()) {
@@ -48,8 +50,19 @@ class ProfileViewModel : ViewModel() {
                 bookmarkCamp.add(camp)
             }
             _bookmarkedList.value = bookmarkCamp
-            Timber.tag("콜북마크검사").d(bookmarkCamp.size.toString())
         }
     }
-
+    fun getPosts(userID: String) {
+        val db = Firebase.firestore
+        val baseQuery: Query = db.collection("posts")
+        val result = baseQuery.whereIn("authorId", listOf("Kakao${userID}"))
+        writingPost.clear()
+        result.get().addOnSuccessListener {
+            for (doc in it) {
+                val post = doc.toObject(PostEntity::class.java)
+                writingPost.add(post)
+            }
+            _postList.value = writingPost
+        }
+    }
 }

--- a/app/src/main/java/com/brandon/campingmate/presentation/profile/adapter/ProfileBookmarkAdapter.kt
+++ b/app/src/main/java/com/brandon/campingmate/presentation/profile/adapter/ProfileBookmarkAdapter.kt
@@ -32,39 +32,11 @@ class ProfileBookmarkAdapter : ListAdapter<CampEntity, ProfileBookmarkAdapter.Ho
                 tvCampInduty.text = data.induty.toString()
 
                 binding.root.setOnClickListener {
-                    val myData = CampEntity(
-                        addr1 = data.addr1,
-                        contentId = data.contentId,
-                        facltNm = data.facltNm,
-                        wtrplCo = data.wtrplCo,
-                        brazierCl = data.brazierCl,
-                        sbrsCl = data.sbrsCl,
-                        posblFcltyCl = data.posblFcltyCl,
-                        hvofBgnde = data.hvofBgnde,
-                        hvofEnddle = data.hvofEnddle,
-                        toiletCo = data.toiletCo,
-                        swrmCo = data.swrmCo,
-                        featureNm = data.featureNm,
-                        induty = data.induty,
-                        tel = data.tel,
-                        homepage = data.homepage,
-                        resveCl = data.resveCl,
-                        siteBottomCl1 = data.siteBottomCl1,
-                        siteBottomCl2 = data.siteBottomCl2,
-                        siteBottomCl3 = data.siteBottomCl3,
-                        siteBottomCl4 = data.siteBottomCl4,
-                        siteBottomCl5 = data.siteBottomCl5,
-                        glampInnerFclty = data.glampInnerFclty,
-                        caravInnerFclty = data.caravInnerFclty,
-                        intro = data.intro,
-                        themaEnvrnCl = data.themaEnvrnCl
-                    )
-
+                    val campId = data.contentId
                     val intent = Intent(binding.root.context, CampDetailActivity::class.java).apply {
-                        putExtra("campData", myData)
+                        putExtra("campData", campId)
                     }
                     binding.root.context.startActivity(intent)
-
                 }
             }
         }

--- a/app/src/main/java/com/brandon/campingmate/presentation/profile/adapter/ProfilePostAdapter.kt
+++ b/app/src/main/java/com/brandon/campingmate/presentation/profile/adapter/ProfilePostAdapter.kt
@@ -1,0 +1,61 @@
+package com.brandon.campingmate.presentation.profile.adapter
+
+import android.content.Intent
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.brandon.campingmate.databinding.ItemPostBinding
+import com.brandon.campingmate.domain.model.PostEntity
+import com.brandon.campingmate.presentation.postdetail.PostDetailActivity
+import com.brandon.campingmate.utils.toFormattedString
+import com.bumptech.glide.Glide
+
+class ProfilePostAdapter : ListAdapter<PostEntity, ProfilePostAdapter.Holder>(diffUtil) {
+    inner class Holder(val binding: ItemPostBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(data: PostEntity) {
+            with(binding) {
+                if(data.imageUrlList.isNullOrEmpty()){
+                    ivPostImage.isVisible = false
+                }else {
+                    Glide.with(binding.root).load(data.imageUrlList.firstOrNull()).into(ivPostImage)
+                }
+                tvTitle.text = data.title
+                tvContent.text = data.content
+                tvTimestamp.text = data.timestamp.toFormattedString()
+
+                binding.root.setOnClickListener {
+                    val postId = data.postId
+                    val intent = Intent(binding.root.context, PostDetailActivity::class.java).apply {
+                        putExtra("extra_post_id",postId)
+                    }
+                    binding.root.context.startActivity(intent)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val diffUtil = object : DiffUtil.ItemCallback<PostEntity>() {
+            override fun areItemsTheSame(oldItem: PostEntity, newItem: PostEntity): Boolean {
+                return oldItem == newItem
+            }
+
+            override fun areContentsTheSame(oldItem: PostEntity, newItem: PostEntity): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        val binding = ItemPostBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return Holder(binding)
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        val item = getItem(position)
+        holder.bind(item)
+    }
+}

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -293,7 +293,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="5dp"
                     android:fontFamily="@font/spoqahansansneo_medium"
-                    android:text="30"
+                    android:text="0"
                     android:textColor="#939393"
                     android:textSize="14sp"
                     android:visibility="gone" />
@@ -321,7 +321,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="5dp"
                     android:fontFamily="@font/spoqahansansneo_medium"
-                    android:text="1000"
+                    android:text="0"
                     android:textColor="#939393"
                     android:textSize="14sp"
                     android:visibility="gone" />

--- a/app/src/main/res/layout/item_post.xml
+++ b/app/src/main/res/layout/item_post.xml
@@ -48,13 +48,14 @@
             android:id="@+id/tv_timestamp"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
+            android:layout_marginTop="8dp"
             android:text="XXXX-XX-XX XX:XX"
             android:textColor="@color/board_gray"
             android:textSize="11sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/tv_title"
-            app:layout_constraintStart_toStartOf="@id/tv_title" />
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_content" />
 
 
         <ImageView


### PR DESCRIPTION
[Feat] 프로필화면에서 작성한 글 확인 기능 구현
- 유저아이디가 일치하는 작성한 글 프로필화면에서 확인 가능
- 작성한 글 클릭 시, 작성한 글의 상세 페이지로 이동 가능

[Fix] 프로필화면에서 캠프상세페이지로 넘어가는 기능 수정
- 캠프장의 contentID로만 페이지로 넘어가서 조회되도록 수정